### PR TITLE
MORPH-486: Fix sub-tenant backup execution and restore for shared Veeam jobs

### DIFF
--- a/src/main/groovy/com/morpheusdata/veeam/backup/VeeamBackupExecutionProviderInterface.groovy
+++ b/src/main/groovy/com/morpheusdata/veeam/backup/VeeamBackupExecutionProviderInterface.groovy
@@ -587,8 +587,32 @@ interface VeeamBackupExecutionProviderInterface extends BackupExecutionProvider 
 
 									if(!veeamHierarchyRef) {
 										veeamHierarchyRef = backupTypeProvider.getVmHierarchyObjRef(backupResult.backup, server)
+										// Still null — hierarchy root was never persisted (e.g. sub-tenant backup where
+										// the managed server dropdown is not shown). Search all managed servers via the
+										// Veeam API to find the correct one, then persist for future use.
+										if(!veeamHierarchyRef) {
+											def vmRefId = backupTypeProvider.getVmRefId(server)
+											if(vmRefId) {
+												def apiVersion = VeeamUtils.getApiVersion(backupProvider)
+												morpheus.services.referenceData.list(new DataQuery().withFilters(
+														new DataFilter("account.id", backupProvider.account.id),
+														new DataFilter("category", "veeam.backup.managedServer.${backupProvider.id}"),
+														new DataFilter("typeValue", backupTypeProvider.getManagedServerType())
+												)).each { ReferenceData managedServer ->
+													if(!veeamHierarchyRef) {
+														def rootRef = apiVersion > 1.3 ? managedServer.getConfigProperty("hierarchyRootUid") : VeeamUtils.extractVeeamUuid(managedServer.keyValue)
+														def candidateRef = backupTypeProvider.getVmHierarchyObjRef(vmRefId, rootRef)
+														def lookupResult = apiService.lookupVm(authConfig.apiUrl, token, candidateRef)
+														if(lookupResult.vmId) {
+															veeamHierarchyRef = candidateRef
+															backup.setConfigProperty("veeamHierarchyRootUid", rootRef)
+														}
+													}
+												}
+											}
+										}
 										backup.setConfigProperty("veeamHierarchyRef", veeamHierarchyRef)
-										doSaveBackup
+										doSaveBackup = true
 									}
 
 									if(!veeamObjectRef) {

--- a/src/main/groovy/com/morpheusdata/veeam/backup/VeeamBackupJobProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/veeam/backup/VeeamBackupJobProvider.groovy
@@ -211,10 +211,8 @@ class VeeamBackupJobProvider implements BackupJobProvider {
 				return ServiceResponse.error("Failed to start Veeam backup job, unable to acquire access token.")
 			}
 
-			Account tmpAccount = opts.account ?: backupJobModel.account
 			List<Backup> jobBackups = []
 			this.morpheus.services.backup.list(new DataQuery().withFilters(
-			        new DataFilter<>('account.id', tmpAccount.id),
 			        new DataFilter<>('backupJob.id', backupJobModel.id),
 					new DataFilter<>('active', true)
 			)).each { Backup backup ->

--- a/src/main/groovy/com/morpheusdata/veeam/backup/VeeamBackupRestoreProviderInterface.groovy
+++ b/src/main/groovy/com/morpheusdata/veeam/backup/VeeamBackupRestoreProviderInterface.groovy
@@ -441,7 +441,7 @@ interface VeeamBackupRestoreProviderInterface extends BackupRestoreProvider {
 			def restorePoint
 			if(restoreLinkResponse.data.name() == "VmRestorePoints") {
 				restorePoint = restoreLinkResponse.data.VmRestorePoint.find { it.HierarchyObjRef.text().toString().toLowerCase() == objectRef?.toLowerCase() || it.VmName.text().toString() == vmName }
-				if(!restorePoint && opts.vCenterVmId) {
+				if(!restorePoint && vCenterVmId) {
 					restorePoint = restoreLinkResponse.data.VmRestorePoint.find { it.HierarchyObjRef.text().toString().endsWith(vCenterVmId) }
 				}
 			} else {


### PR DESCRIPTION
Description:

Summary

Three bugs preventing sub-tenant instances from being backed up and restored when using a Veeam job shared from the master tenant.

Root Causes & Fixes

1. Sub-tenant backup results never created (MORPH-486)

executeBackupJob queried Backup records filtered by account.id (master tenant), silently excluding sub-tenant instances. Removed the account.id filter — backupJob.id is sufficient to scope the query correctly.

File: VeeamBackupJobProvider.groovy

2. Restore crash — MissingPropertyException: opts.vCenterVmId

getRestoreLinkFromRestorePoints was refactored in Feb 2024 to accept individual parameters (vmName, vCenterVmId) instead of an opts map, but one reference was not updated. Caused a crash on the fallback restore point lookup path.

File: VeeamBackupRestoreProviderInterface.groovy

3. Self-healing hierarchy root resolution + doSaveBackup no-op

Sub-tenant backups never have veeamHierarchyRootUid set because the managed server dropdown in the Morpheus UI is scoped to the master tenant's ReferenceData — sub-tenants never see it. This caused a Veeam 500 (HierarchyObjRef=="null") on restore.

Two issues fixed in refreshBackupResult:

 - When veeamHierarchyRef is null, iterate all managed servers for the provider and call lookupVm until the VM is found, then persist veeamHierarchyRootUid and veeamHierarchyRef via morpheus.async.backup.save(backup). Runs once on first successful backup poll — self-heals without any user action.
 - doSaveBackup was a bare no-op statement (Groovy evaluates it as an expression, not an assignment). Changed to doSaveBackup = true. Present since the original implementation — even when the ref was resolved in memory it was never saved.

File: VeeamBackupExecutionProviderInterface.groovy

Testing

 - Confirmed in lab environment running Morpheus 9.0.1-dev
 - Sub-tenant backup execution creates BackupResult records correctly
 - Restore from sub-tenant completes successfully after self-healing on first backup poll
 - Master tenant backup/restore unaffected

Jira

MORPH-486: https://morpheusdata.atlassian.net/browse/MORPH-486