### PR TITLE
MORPH-14095: Port option sources to plugin dataset providers

### DIFF
--- a/src/main/groovy/com/morpheusdata/veeam/VeeamPlugin.groovy
+++ b/src/main/groovy/com/morpheusdata/veeam/VeeamPlugin.groovy
@@ -20,6 +20,8 @@ import com.morpheusdata.core.Plugin
 import com.morpheusdata.model.AccountCredential
 import com.morpheusdata.model.BackupProvider
 import com.morpheusdata.veeam.backup.VeeamBackupProvider
+import com.morpheusdata.veeam.datasets.VeeamBackupRepositoryDatasetProvider
+import com.morpheusdata.veeam.datasets.VeeamManagedServerDatasetProvider
 import com.morpheusdata.veeam.services.ApiService
 import groovy.util.logging.Slf4j
 
@@ -39,6 +41,8 @@ class VeeamPlugin extends Plugin {
 		this.apiService = new ApiService(this)
         this.registerProvider(new VeeamBackupProvider(this,this.morpheus, apiService))
 	    this.registerProvider(new VeeamOptionSourceProvider(this,this.morpheus, apiService))
+	    this.registerProvider(new VeeamManagedServerDatasetProvider(this,this.morpheus))
+	    this.registerProvider(new VeeamBackupRepositoryDatasetProvider(this,this.morpheus))
     }
 
     /**

--- a/src/main/groovy/com/morpheusdata/veeam/datasets/VeeamBackupRepositoryDatasetProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/veeam/datasets/VeeamBackupRepositoryDatasetProvider.groovy
@@ -1,0 +1,164 @@
+package com.morpheusdata.veeam.datasets
+
+import com.morpheusdata.core.MorpheusContext
+import com.morpheusdata.core.Plugin
+import com.morpheusdata.core.data.DataAndFilter
+import com.morpheusdata.core.data.DataFilter
+import com.morpheusdata.core.data.DataOrFilter
+import com.morpheusdata.core.data.DataQuery
+import com.morpheusdata.core.data.DatasetInfo
+import com.morpheusdata.core.data.DatasetQuery
+import com.morpheusdata.core.providers.AbstractDatasetProvider
+import com.morpheusdata.model.BackupRepository
+import com.morpheusdata.model.ResourcePermission
+import groovy.util.logging.Slf4j
+import io.reactivex.rxjava3.core.Observable
+
+/**
+ * Dataset provider that lists the Veeam backup repositories available for a backup provider, ported from the
+ * embedded {@code VeeamOptionSourceService#veeamBackupRepository}.
+ */
+@Slf4j
+class VeeamBackupRepositoryDatasetProvider extends AbstractDatasetProvider<BackupRepository, Long> {
+
+    public static final providerName = 'Veeam Backup Repository Dataset Provider'
+    public static final providerNamespace = 'veeam'
+    public static final providerKey = 'veeamBackupRepository'
+    public static final providerDescription = 'A set of backup repositories from Veeam'
+
+    VeeamBackupRepositoryDatasetProvider(Plugin plugin, MorpheusContext morpheus) {
+        this.plugin = plugin
+        this.morpheusContext = morpheus
+    }
+
+    @Override
+    DatasetInfo getInfo() {
+        new DatasetInfo(
+                name: providerName,
+                namespace: providerNamespace,
+                key: providerKey,
+                description: providerDescription
+        )
+    }
+
+    /**
+     * the class type of the data for this provider
+     * @return the class this provider operates on
+     */
+    @Override
+    Class<BackupRepository> getItemType() {
+        return BackupRepository.class
+    }
+
+    /**
+     * list the backup repository records accessible to the current account
+     * @param query the user and map of query params or options to apply to the list
+     * @return a list of objects
+     */
+    @Override
+    Observable<BackupRepository> list(DatasetQuery query) {
+        log.debug("backup repository list: ${query.parameters}")
+        def account = query.user?.account
+        Long cloudId = query.get("zoneId")?.toLong()
+        if (!account || !cloudId) {
+            return Observable.empty()
+        }
+        def backupProvider = resolveBackupProvider(cloudId, account)
+        if (backupProvider) {
+            def accessibleResourceIds = morpheus.services.resourcePermission.listAccessibleResources(account.id, ResourcePermission.ResourceType.BackupRepository, null, null)
+            def dataQuery = new DataQuery().withFilters([
+                    new DataFilter("backupProvider.id", backupProvider.id),
+                    new DataFilter("enabled", true)
+            ])
+            def dataOrFilter = new DataOrFilter(
+                    new DataFilter("account", account),
+                    new DataAndFilter(
+                            new DataFilter("account.masterAccount", true),
+                            new DataFilter("visibility", "public")
+                    )
+            )
+            if (accessibleResourceIds) {
+                dataOrFilter.withFilter(new DataFilter("id", "in", accessibleResourceIds))
+            }
+            dataQuery.withFilter(dataOrFilter)
+            return morpheus.services.backupRepository.list(dataQuery)
+        }
+        return Observable.empty()
+    }
+
+    /**
+     * list the backup repositories as name/value pairs, mirroring the embedded option source output.
+     * @param query a DatasetQuery containing the user and map of query params or options to apply to the list
+     * @return a list of maps that have name value pairs of the items
+     */
+    @Override
+    Observable<Map> listOptions(DatasetQuery query) {
+        log.debug("backup repositories: ${query.parameters}")
+        List repos = []
+        def existingRepositories = list(query).toList().blockingGet()
+        if (existingRepositories?.size() > 0) {
+            existingRepositories.each { repo ->
+                def repoConfig = repo.getConfigMap()
+                def backupServer = repoConfig?.links?.link?.find { it.type == "BackupServerReference" }?.name
+                def repoName = backupServer ? "${repo.name} (Backup Server: ${backupServer})" : repo.name
+                repos << [id: repo.id, name: repoName, code: repo.code, internalId: repo.internalId, value: repo.id]
+            }
+        } else {
+            repos << [name: "No repositories setup in Veeam", id: '']
+        }
+        return Observable.fromIterable(repos)
+    }
+
+    /**
+     * Resolve the veeam backup provider associated with the given cloud.
+     */
+    private resolveBackupProvider(Long cloudId, account) {
+        def cloud = morpheus.async.cloud.get(cloudId).blockingGet()
+        def backupProvider
+        if (cloud?.backupProviders) {
+            def backupProviderIds = cloud.backupProviders.collect { it.id }
+            def backupProviders = morpheus.services.backupProvider.listById(backupProviderIds).toList()
+            backupProvider = backupProviders.find { it.type.code == 'veeam' }
+        }
+        return backupProvider
+    }
+
+    @Override
+    BackupRepository fetchItem(Object value) {
+        def rtn = null
+        if (value instanceof Long) {
+            rtn = item((Long) value)
+        } else if (value instanceof CharSequence) {
+            def longValue = value.isNumber() ? value.toLong() : null
+            if (longValue) {
+                rtn = item(longValue)
+            }
+        }
+        return rtn
+    }
+
+    @Override
+    BackupRepository item(Long value) {
+        return morpheus.services.backupRepository.get(value)
+    }
+
+    /**
+     * gets the name for an item
+     * @param item an item
+     * @return the corresponding name for the name/value pair list
+     */
+    @Override
+    String itemName(BackupRepository item) {
+        return item.name
+    }
+
+    /**
+     * gets the value for an item
+     * @param item an item
+     * @return the corresponding value for the name/value pair list
+     */
+    @Override
+    Long itemValue(BackupRepository item) {
+        return item.id
+    }
+}

--- a/src/main/groovy/com/morpheusdata/veeam/datasets/VeeamManagedServerDatasetProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/veeam/datasets/VeeamManagedServerDatasetProvider.groovy
@@ -1,0 +1,239 @@
+package com.morpheusdata.veeam.datasets
+
+import com.morpheusdata.core.MorpheusContext
+import com.morpheusdata.core.Plugin
+import com.morpheusdata.core.data.DataAndFilter
+import com.morpheusdata.core.data.DataFilter
+import com.morpheusdata.core.data.DataOrFilter
+import com.morpheusdata.core.data.DataQuery
+import com.morpheusdata.core.data.DatasetInfo
+import com.morpheusdata.core.data.DatasetQuery
+import com.morpheusdata.core.providers.AbstractDatasetProvider
+import com.morpheusdata.model.ReferenceData
+import com.morpheusdata.model.ResourcePermission
+import com.morpheusdata.veeam.utils.VeeamUtils
+import groovy.util.logging.Slf4j
+import io.reactivex.rxjava3.core.Observable
+
+/**
+ * Dataset provider that lists the Veeam managed servers available for a backup provider, ported from the
+ * embedded {@code VeeamOptionSourceService#veeamManagedServer}.
+ */
+@Slf4j
+class VeeamManagedServerDatasetProvider extends AbstractDatasetProvider<ReferenceData, String> {
+
+    public static final providerName = 'Veeam Managed Server Dataset Provider'
+    public static final providerNamespace = 'veeam'
+    public static final providerKey = 'veeamManagedServer'
+    public static final providerDescription = 'A set of managed servers from Veeam'
+
+    VeeamManagedServerDatasetProvider(Plugin plugin, MorpheusContext morpheus) {
+        this.plugin = plugin
+        this.morpheusContext = morpheus
+    }
+
+    @Override
+    DatasetInfo getInfo() {
+        new DatasetInfo(
+                name: providerName,
+                namespace: providerNamespace,
+                key: providerKey,
+                description: providerDescription
+        )
+    }
+
+    /**
+     * the class type of the data for this provider
+     * @return the class this provider operates on
+     */
+    @Override
+    Class<ReferenceData> getItemType() {
+        return ReferenceData.class
+    }
+
+    /**
+     * list the managed server reference data records accessible to the current account
+     * @param query the user and map of query params or options to apply to the list
+     * @return a list of objects
+     */
+    @Override
+    Observable<ReferenceData> list(DatasetQuery query) {
+        log.debug("managed server list: ${query.parameters}")
+        def account = query.user?.account
+        if (!account) {
+            return Observable.empty()
+        }
+        def managedServerType = resolveManagedServerType(query)
+        def backupProvider = resolveBackupProvider(query, account)
+        if (backupProvider) {
+            def accessibleResourceIds = morpheus.services.resourcePermission.listAccessibleResources(account.id, ResourcePermission.ResourceType.ManagedServer, null, null)
+            def dataQuery = new DataQuery().withFilters([
+                    new DataFilter("account", backupProvider.account),
+                    new DataFilter("category", "veeam.backup.managedServer.${backupProvider.id}"),
+                    new DataFilter("typeValue", managedServerType),
+                    new DataFilter("enabled", true)
+            ])
+            def dataOrFilter = new DataOrFilter(
+                    new DataFilter("account", account),
+                    new DataAndFilter(
+                            new DataFilter("account.masterAccount", true),
+                            new DataFilter("visibility", "public")
+                    )
+            )
+            if (accessibleResourceIds) {
+                dataOrFilter.withFilter(new DataFilter("id", "in", accessibleResourceIds))
+            }
+            dataQuery.withFilter(dataOrFilter)
+            return morpheus.services.referenceData.list(dataQuery)
+        }
+        return Observable.empty()
+    }
+
+    /**
+     * list the managed servers as name/value pairs, mirroring the embedded option source output.
+     * @param query a DatasetQuery containing the user and map of query params or options to apply to the list
+     * @return a list of maps that have name value pairs of the items
+     */
+    @Override
+    Observable<Map> listOptions(DatasetQuery query) {
+        log.debug("managed servers: ${query.parameters}")
+        List servers = []
+        def account = query.user?.account
+        def managedServerType = resolveManagedServerType(query)
+        def repoBackupServerId = resolveRepoBackupServerId(query)
+        def backupProvider = account ? resolveBackupProvider(query, account) : null
+        if (backupProvider) {
+            def existingManagedServers = list(query).toList().blockingGet()
+            if (existingManagedServers.size() > 0) {
+                existingManagedServers.each { managedServer ->
+                    def managedServerConfig = managedServer.getConfigMap()
+                    if (managedServerConfig?.managedServerType == managedServerType) {
+                        def backupServerName = ""
+                        def id = null
+                        def backupServerId
+                        if (managedServerConfig.managedServerId && managedServerConfig.backupServerId) {
+                            id = managedServerConfig.managedServerId + ":" + managedServerConfig.backupServerId
+                            backupServerName = " (Backup Server: " + managedServerConfig.backupServerName + ")"
+                            backupServerId = managedServerConfig.backupServerId
+                        } else {
+                            def managedServerLink = managedServerConfig.links?.link.find { it.type == "ManagedServerReference" }
+                            def backupServerLink = managedServerConfig.links?.link.find { it.type == "BackupServer" }
+                            def managedServerId = VeeamUtils.extractVeeamUuid(managedServerLink.href)
+                            backupServerId = VeeamUtils.extractVeeamUuid(backupServerLink.href)
+                            backupServerName = " (Backup Server: " + (backupServerLink?.name ?: "N/A") + ")"
+                            id = "${managedServerId}:${backupServerId}"
+                        }
+                        if (!backupServerId || !repoBackupServerId || (repoBackupServerId == backupServerId)) {
+                            def value = managedServer.name + backupServerName
+                            servers << [name: value, id: id, value: id]
+                        }
+                    }
+                }
+            } else {
+                servers << [name: "No managed servers setup in Veeam", id: '']
+            }
+        } else {
+            servers << [name: "No Veeam backup provider found.", id: '']
+        }
+        return Observable.fromIterable(servers)
+    }
+
+    /**
+     * Resolve the cloud from either the container (workload) or zone id supplied in the query params.
+     */
+    private resolveCloud(DatasetQuery query, account) {
+        def cloud
+        Long containerId = query.get("containerId")?.toLong()
+        Long cloudId = query.get("zoneId")?.toLong()
+        if (containerId && !cloudId) {
+            def workload = morpheus.services.workload.find(new DataQuery().withFilter("account", account).withFilter("containerId", containerId))
+            cloud = workload?.server?.cloud
+        }
+        if (!cloud && cloudId) {
+            cloud = morpheus.async.cloud.get(cloudId).blockingGet()
+        }
+        return cloud
+    }
+
+    /**
+     * Resolve the veeam backup provider associated with the cloud referenced by the query params.
+     */
+    private resolveBackupProvider(DatasetQuery query, account) {
+        def cloud = resolveCloud(query, account)
+        def backupProvider
+        if (cloud?.backupProviders) {
+            def backupProviderIds = cloud.backupProviders.collect { it.id }
+            def backupProviders = morpheus.services.backupProvider.listById(backupProviderIds).toList()
+            backupProvider = backupProviders.find { it.type.code == 'veeam' }
+        }
+        return backupProvider
+    }
+
+    /**
+     * Derive the managed server type from the zone type or backup type supplied in the query params.
+     */
+    private String resolveManagedServerType(DatasetQuery query) {
+        String managedServerType = ""
+        def zoneType = query.get("zoneType")
+        def backupType = query.get("backupType")
+        def backupTypeId = query.get("backupTypeId")
+        if (backupTypeId && backupTypeId.toString().isLong()) {
+            backupType = morpheus.services.backup.type.get(backupTypeId.toLong())?.code
+        }
+        if (zoneType == 'vmware' || backupType == 'veeamVMWareBackup') {
+            managedServerType = "VC"
+        } else if (zoneType == 'hyperv' || backupType == 'veeamHypervBackup') {
+            managedServerType = "HvServer"
+        } else if (zoneType == 'scvmm' || backupType == 'veeamScvmmBackup') {
+            managedServerType = 'Scvmm'
+        } else if (zoneType == 'vcd' || backupType == 'veeamVcdBackup') {
+            managedServerType = 'VcdSystem'
+        }
+        return managedServerType
+    }
+
+    /**
+     * Resolve the backup server id associated with the selected repository, used to filter managed servers.
+     */
+    private resolveRepoBackupServerId(DatasetQuery query) {
+        def repoBackupServerId
+        def repositoryId = query.get("repositoryId")
+        if (repositoryId && repositoryId.toString().isLong()) {
+            def repo = morpheus.services.backupRepository.get(repositoryId.toLong())
+            def repoConfig = repo?.getConfigMap()
+            def backupServerHref = repoConfig?.links?.link?.find { it.type == "BackupServerReference" }?.href
+            repoBackupServerId = VeeamUtils.extractVeeamUuid(backupServerHref)
+        }
+        return repoBackupServerId
+    }
+
+    @Override
+    ReferenceData fetchItem(Object value) {
+        return null
+    }
+
+    @Override
+    ReferenceData item(String value) {
+        return null
+    }
+
+    /**
+     * gets the name for an item
+     * @param item an item
+     * @return the corresponding name for the name/value pair list
+     */
+    @Override
+    String itemName(ReferenceData item) {
+        return item.name
+    }
+
+    /**
+     * gets the value for an item
+     * @param item an item
+     * @return the corresponding value for the name/value pair list
+     */
+    @Override
+    String itemValue(ReferenceData item) {
+        return item.id?.toString()
+    }
+}


### PR DESCRIPTION
## Summary

Ports the embedded `VeeamOptionSourceService` methods into the plugin as `AbstractDatasetProvider` implementations, using `rc-9.0.2` as the source of truth ([MORPH-14095](https://hpe.atlassian.net/browse/MORPH-14095)).

New providers under `com.morpheusdata.veeam.datasets` (registered in `VeeamPlugin.initialize()`):

- **`VeeamManagedServerDatasetProvider`** (namespace `veeam`, key `veeamManagedServer`) — ports `veeamManagedServer`, including managed-server-type derivation from `zoneType`/`backupType`/`backupTypeId`, repository-based backup-server filtering, and accessible-resource permission filtering. Preserves the composite `managedServerId:backupServerId` option value.
- **`VeeamBackupRepositoryDatasetProvider`** (namespace `veeam`, key `veeamBackupRepository`) — ports `veeamBackupRepository`.

Both filter accessible resources via the non-deprecated `resourcePermission` service using `ResourcePermission.ResourceType.ManagedServer` / `BackupRepository`, and use the correct master-tenant visibility filter (`account.masterAccount = true`).

## Dependency

Requires the `ResourcePermission.ResourceType` additions in morpheus-plugin-core PR #211 (published as `1.5.0-SNAPSHOT`).

## Follow-up

Surfacing these datasets in the plugin backup forms (via `OptionType`/`optionSource`) is tracked in [MORPH-14096](https://hpe.atlassian.net/browse/MORPH-14096); embedded consumed them through GSP taglibs, so there was no `OptionType` to port here.