### PR TITLE
WIP

### DIFF
--- a/src/main/groovy/com/morpheusdata/veeam/VeeamOptionSourceProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/veeam/VeeamOptionSourceProvider.groovy
@@ -14,6 +14,8 @@ class VeeamOptionSourceProvider extends AbstractOptionSourceProvider {
 	VeeamPlugin plugin
 	MorpheusContext morpheusContext
 	ApiService apiService
+	boolean hasSchedule
+	boolean hasRetentionCount
 
 	VeeamOptionSourceProvider(VeeamPlugin plugin, MorpheusContext context, ApiService) {
 		this.plugin = plugin

--- a/src/main/groovy/com/morpheusdata/veeam/backup/VeeamBackupProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/veeam/backup/VeeamBackupProvider.groovy
@@ -139,6 +139,7 @@ class VeeamBackupProvider extends AbstractBackupProvider {
 	 */
 	@Override
 	public Boolean getHasSchedule() { return true; }
+	
 
 	/**
 	 * The backup provider supports running multiple workload backups within an encapsulating job.


### PR DESCRIPTION
Got it. I still can’t reliably inspect that plugin repo from URL text alone in this session unless I can fetch it via tools.

Fastest path: I can still give you a **precise implementation target checklist** from PR #4894 (what your Veeam plugin must expose), which you can map in `api-1.5.x` immediately:

## Must-have in `morpheus-veeam-plugin` (api-1.5.x)

- **Backup provider capabilities surfaced in provider metadata**
  - `hasSchedule = true/false` (accurate)
  - `hasRetentionCount = true/false` (accurate/persisted)
- **Option discovery from plugin datasets/option sources** for all Veeam backup form fields the UI still references.
- **Run-now / job-form compatibility** driven by plugin metadata, not provider-name checks.
- **Clone/schedule visibility compatibility** driven by capabilities, not `provider.code/name` substring.
- **Automation/template config fields** backed by plugin option types (so UI TODO sections can be removed).
- **API/CLI backup option discovery parity** (the MORPH-133 direction): plugin should provide the same discoverable options previously expected from embedded core paths.

## Likely concrete code areas in plugin to verify

1. Provider/backup type model class:
   - emits `hasSchedule`, `hasRetentionCount`
2. Option type registration:
   - declares all backup config fields with proper dependencies
3. Dataset/option source providers:
   - repository choices
   - managed server/proxy choices
   - job/policy/backup set related choices (where applicable)
4. Execute/run-now capability:
   - explicit capability and action wiring
5. Retention:
   - retention count field persistence and validation

## Definition of done (for this UI PR)

- No UI behavior relies on Veeam name checks for schedule/retention/run-now.
- All required dropdowns/options resolve from plugin providers.
- Existing backup create/edit/clone/schedule/run-now flows work without embedded Veeam-specific UI logic.
- Option discovery works consistently in UI + API/CLI paths.

---

If you want a true **line-by-line gap matrix** (implemented vs missing in `api-1.5.x`), I can do it as soon as you provide either:
- a repo context block for `HewlettPackard/morpheus-veeam-plugin`, or
- tarball / pasted files for provider type + option source classes.